### PR TITLE
Re-enable Secure DNS

### DIFF
--- a/brave_debloat.sh
+++ b/brave_debloat.sh
@@ -95,6 +95,7 @@ apply_brave_policies() {
     "BookmarksBarEnabled": true,
     "SyncDisabled": true,
     "BraveSyncEnabled": false
+    "DnsOverHttpsMode": "automatic"
 }
 EOF
 


### PR DESCRIPTION
By applying group policies brave will force disable Secure DNS. This feature is still helpful, in my case i want to use cloudflare DNS only on my browser because my ISP block reddit and other website for some reason. Feel free to close this PR if you see this change not relevant.

There's three option to choose :

- off: Disables secure DNS
- automatic: Enable secure DNS with insecure fallback (Default_
- secure: Enable secure DNS without insecure fallback
 